### PR TITLE
Add Promise-sync mode

### DIFF
--- a/api/psync.js
+++ b/api/psync.js
@@ -1,0 +1,22 @@
+/*
+ * PHPify - Browserify transform
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpify
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpify/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+/*global global */
+var API = require('../src/API'),
+    FileSystem = require('../src/FileSystem'),
+    Loader = require('../src/Loader'),
+    Performance = require('../src/Performance'),
+    performance = new Performance(Date, global),
+    phpRuntime = require('phpruntime/psync'),
+    api = new API(FileSystem, Loader, phpRuntime, performance),
+    loader = api.createLoader();
+
+module.exports = loader;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -34,9 +34,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -147,6 +147,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -208,10 +217,39 @@
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
+    "es-abstract": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "es5-ext": {
-      "version": "0.10.50",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
-      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "version": "0.10.51",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -228,13 +266,36 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1",
-        "es5-ext": "~0.10.14"
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51"
       }
     },
     "es6-weak-map": {
@@ -281,6 +342,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -322,10 +392,16 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -353,10 +429,25 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "he": {
@@ -393,9 +484,56 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -492,6 +630,22 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -519,10 +673,28 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -591,76 +763,57 @@
       }
     },
     "phpcommon": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.12.1.tgz",
-      "integrity": "sha512-77D4GoaNbbsZT4xULZjVJ6QXDhXfBRks2Fgog5mlsQhPGcn9pNiD1yKQnhkOfJRbC4rb4tT7f+eqhGIPjn6CKQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.13.0.tgz",
+      "integrity": "sha512-gPBLulAOD0seWGPnqrLgZsNv4u5TosPtdTPQu6oquHLR4VelV2ydV1W6sX76VEkARvs3aOm0ohcLGegQ8Pi1bg==",
       "requires": {
         "microdash": "~1",
         "template-string": "~1"
       }
     },
     "phpcore": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/phpcore/-/phpcore-5.8.0.tgz",
-      "integrity": "sha512-2xM1RDwyOwu2w9vVoSG6P1eS/aPikpfm86dr1MN3f3Q4PEf47zb4IroBAJJh7At+nLgfCYGYPeNmLYAl3Sansg==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/phpcore/-/phpcore-5.9.0.tgz",
+      "integrity": "sha512-gGefcMZVMHISJnu+SdP4hj58C5ULlnYLYg+vp8/AzbzHDEQd8kKw+hIOBtaBnMSdDNkii/gQbbJLIpvlDozELg==",
       "requires": {
         "es6-weak-map": "^2.0.3",
+        "is-promise": "^2.1.0",
         "lie": "^3.0.1",
         "microdash": "~1",
         "pausable": "~4",
         "pauser": "~1",
-        "phpcommon": "^1.12.1"
-      },
-      "dependencies": {
-        "phpcommon": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.12.1.tgz",
-          "integrity": "sha512-77D4GoaNbbsZT4xULZjVJ6QXDhXfBRks2Fgog5mlsQhPGcn9pNiD1yKQnhkOfJRbC4rb4tT7f+eqhGIPjn6CKQ==",
-          "requires": {
-            "microdash": "~1",
-            "template-string": "~1"
-          }
-        }
+        "phpcommon": "^1.13.0"
       }
     },
     "phpruntime": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/phpruntime/-/phpruntime-6.0.1.tgz",
-      "integrity": "sha512-QngajgWRE97I6o9GaJGN3ppzZNbA5p1y2JpSjjrW/G5uNzwn9BUIUWPrx4o3Ypy8oHf4Kew+Nr15uGXtWziwSQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/phpruntime/-/phpruntime-6.2.0.tgz",
+      "integrity": "sha512-ywNV6b55DqPW34pq2LAMByBhD1PQZKP+oES2Q8HhONrcpoL5ZnAFkZYDqvqEKGGKTgQ7bFyMChbT0/2XbU/1Jg==",
       "requires": {
         "microdash": "~1",
-        "phpcommon": "^1.12.1",
-        "phpcore": "^5.8.0"
-      },
-      "dependencies": {
-        "phpcommon": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.12.1.tgz",
-          "integrity": "sha512-77D4GoaNbbsZT4xULZjVJ6QXDhXfBRks2Fgog5mlsQhPGcn9pNiD1yKQnhkOfJRbC4rb4tT7f+eqhGIPjn6CKQ==",
-          "requires": {
-            "microdash": "~1",
-            "template-string": "~1"
-          }
-        }
+        "phpcommon": "^1.13.0",
+        "phpcore": "^5.9.0",
+        "regextend": "^1.0.0"
       }
     },
     "phptoast": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/phptoast/-/phptoast-6.0.4.tgz",
-      "integrity": "sha512-EKLS2d/dzE5wAdh+t4Um4knb69x1vWIb3jM/6/9llOSfW+ei+CzGLLEEu0cTm36IR/zcYBVnl+ATaSJFvJmJFA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/phptoast/-/phptoast-7.0.0.tgz",
+      "integrity": "sha512-wF3fPXVHN3he06VLTUnx3ZGyVa6yEvbksiy+PdYN4TJtXDGrVh7Qia9LXuaMZ4vEDQIYu+64iRPq24aMb1UtnA==",
       "requires": {
         "microdash": "~1",
         "parsing": "^2.0.0",
-        "phpcommon": "^1.12.1"
+        "phpcommon": "^1.13.0"
       }
     },
     "phptojs": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-6.1.2.tgz",
-      "integrity": "sha512-Rb5qrZqsna4VuEYB+TkYDqVW8RSFskVF2RO1VyBgUBj2EA0u1yNoGZZGA9+bgPno+LiDAbAW2KGFp4D9JiRzNQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-7.1.0.tgz",
+      "integrity": "sha512-xTvtRaf/sehpry5G4vvnrCoSPXBEHSnH/B5uRcOP7DoSRTKl5jnI/6+LxcFKNIPZfp92KRcNbA4+PlVa+mlGCQ==",
       "requires": {
+        "es6-set": "^0.1.5",
         "microdash": "~1",
-        "phpcommon": "^1.12.1",
+        "phpcommon": "^1.13.0",
         "source-map": "^0.5.6",
         "source-map-to-comment": "^1.1.0",
         "transpiler": "~1.2"
@@ -708,6 +861,14 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "regextend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regextend/-/regextend-1.0.0.tgz",
+      "integrity": "sha512-Rab7FgwuBAiGNH4tMlCwXkWGU/Fi2Pvur3iDftjUjbUKv743YLQWl7E66Pyv0deybdwhJH93YAzgav73wqBTlQ==",
+      "requires": {
+        "microdash": "~1"
+      }
+    },
     "require-resolve": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
@@ -715,6 +876,12 @@
       "requires": {
         "x-path": "^0.0.2"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "samsam": {
       "version": "1.1.2",
@@ -757,6 +924,26 @@
       "resolved": "https://registry.npmjs.org/source-map-to-comment/-/source-map-to-comment-1.1.0.tgz",
       "integrity": "sha1-5RjEC8c5my4jyOMxoRY1qXdQ6cM="
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -798,9 +985,9 @@
       }
     },
     "type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -817,20 +1004,16 @@
       "dev": true
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "lie": "^3.3.0",
     "microdash": "~1",
     "nowdoc": "~1.0",
-    "phpruntime": "^6.0.1",
-    "phptoast": "^6.0.4",
-    "phptojs": "^6.1.2",
+    "phpruntime": "^6.2.0",
+    "phptoast": "^7.0.0",
+    "phptojs": "^7.1.0",
     "require-resolve": "0.0.2"
   },
   "devDependencies": {

--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -11,6 +11,7 @@
 
 var _ = require('microdash'),
     INCLUDE = 'include',
+    MODE = 'mode',
     SYNC = 'sync',
     nowdoc = require('nowdoc'),
     path = require('path');
@@ -62,9 +63,12 @@ _.extend(Transformer.prototype, {
     transform: function (config, content, file, configDir) {
         var transformer = this,
             phpToJSConfig = config.phpToJS || {},
+            mode = phpToJSConfig[SYNC] === true ?
+                'sync' :
+                (phpToJSConfig[MODE] || 'async'),
             apiPath = path.dirname(transformer.resolveRequire('phpify')) +
                 '/api' +
-                (phpToJSConfig[SYNC] ? '/sync' : ''),
+                (mode === 'async' ? '' : '/' + mode),
             js,
             prefixJS,
             runtimePath = path.dirname(transformer.resolveRequire('phpruntime')),

--- a/test/integration/apiTest.js
+++ b/test/integration/apiTest.js
@@ -12,6 +12,7 @@
 var asyncAPI = require('../../api/async'),
     expect = require('chai').expect,
     phpify = require('../..'),
+    psyncAPI = require('../../api/psync'),
     syncAPI = require('../../api/sync'),
     Loader = require('../../src/Loader');
 
@@ -26,5 +27,9 @@ describe('Public API integration', function () {
 
     it('should export a Loader as the sync API entrypoint', function () {
         expect(syncAPI).to.be.an.instanceOf(Loader);
+    });
+
+    it('should export a Loader as the psync API entrypoint', function () {
+        expect(psyncAPI).to.be.an.instanceOf(Loader);
     });
 });

--- a/test/integration/transpileTest.js
+++ b/test/integration/transpileTest.js
@@ -77,12 +77,48 @@ describe('Transpilation integration', function () {
         expect(module.exports().execute().getNative()).to.equal(21);
     });
 
-    it('should transpile a simple PHP file to executable JS in asynchronous mode', function (done) {
+    it('should transpile a simple PHP file to executable JS in asynchronous mode using the "sync" option', function (done) {
         var compiledModule,
             exports = {},
             module = {exports: exports},
             transpiledJS;
         this.config.phpToJS.sync = false; // Use async mode
+        transpiledJS = this.transformer.transform(this.config, '<?php return 1001;', 'my/entry.php', this.configDir);
+        compiledModule = new Function('require', 'module', 'exports', transpiledJS);
+
+        compiledModule(this.hookedRequire, module, exports);
+
+        module.exports().execute().then(function (resultValue) {
+            expect(resultValue.getNative()).to.equal(1001);
+            done();
+        }, done).catch(done);
+    });
+
+    it('should transpile a simple PHP file to executable JS in asynchronous mode using the "mode" option', function (done) {
+        var compiledModule,
+            exports = {},
+            module = {exports: exports},
+            transpiledJS;
+        delete this.config.phpToJS.sync; // Use async mode
+        this.config.phpToJS.mode = 'async';
+        transpiledJS = this.transformer.transform(this.config, '<?php return 1001;', 'my/entry.php', this.configDir);
+        compiledModule = new Function('require', 'module', 'exports', transpiledJS);
+
+        compiledModule(this.hookedRequire, module, exports);
+
+        module.exports().execute().then(function (resultValue) {
+            expect(resultValue.getNative()).to.equal(1001);
+            done();
+        }, done).catch(done);
+    });
+
+    it('should transpile a simple PHP file to executable JS in Promise-synchronous mode using the "mode" option', function (done) {
+        var compiledModule,
+            exports = {},
+            module = {exports: exports},
+            transpiledJS;
+        delete this.config.phpToJS.sync; // Use async mode
+        this.config.phpToJS.mode = 'psync';
         transpiledJS = this.transformer.transform(this.config, '<?php return 1001;', 'my/entry.php', this.configDir);
         compiledModule = new Function('require', 'module', 'exports', transpiledJS);
 


### PR DESCRIPTION
This change allows a consistent public API across async mode and (p)sync modes. Previously, the consuming application needed to deal with either a Promise (as returned in async mode) or the resulting Value object. This additional effort made it more likely that only one of the options would be supported, meaning that switching between modes (eg. to enable the experimental debugger) would involve code changes.

Also see:

PHPToJS PR: uniter/phptojs#4
PHPCore PR: uniter/phpcore#3
PHPRuntime PR: uniter/phpruntime#8